### PR TITLE
Certificate Verification and set attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ hass = Hass(hassurl="http://IP_ADDRESS:8123/", token="YOUR_HASS_TOKEN")
 
 hass.turn_on("light.bedroom_light")
 hass.run_script("good_morning")
+
+# If you want to bypass certificate verification. Default set to True
+hass = Hass(hassurl="http://IP_ADDRESS:8123/", token="YOUR_HASS_TOKEN", verify=False)
 ```
 ## Installation
 ```

--- a/src/hassapi/client/auth.py
+++ b/src/hassapi/client/auth.py
@@ -8,10 +8,11 @@ from typing import Dict, Optional
 class AuthenticatedClient:
     """Class for HASS API authentication."""
 
-    def __init__(self, hassurl: Optional[str] = None, token: Optional[str] = None):
+    def __init__(self, hassurl: Optional[str] = None, token: Optional[str] = None, verify: Optional[bool] = True):
         """Create Authenticated client."""
         self._url = self._resolve_api_url(hassurl or os.environ["HASS_URL"])
         self._headers = self._get_headers(token or os.environ["HASS_TOKEN"])
+        self._verify = verify
 
     def _resolve_api_url(self, hassurl: str) -> str:
         """Resolve if needed and get full API url."""

--- a/src/hassapi/client/base.py
+++ b/src/hassapi/client/base.py
@@ -9,6 +9,10 @@ from hassapi.exceptions import ClientError, get_error
 
 from .auth import AuthenticatedClient
 
+
+"""Uncomment the below if you don't want InsecureRequestWarning output when using verify=False"""
+# requests.packages.urllib3.disable_warnings()
+
 JsonResponseType = Union[Dict, List, str]
 HassValueType = Union[int, float, str, bool]
 
@@ -17,15 +21,16 @@ class BaseClient(AuthenticatedClient):
     """Class for basic API client functionality."""
 
     def __init__(
-        self, hassurl: Optional[str] = None, token: Optional[str] = None, timeout: float = 3
+        self, hassurl: Optional[str] = None, token: Optional[str] = None, verify: Optional[bool] = None, timeout: float = 3
     ):
         """Create Base Client object.
 
         Args:
             hassurl: Home Assistant url e.g. http://localhost:8123
             token: Home Assistant token
+            verify: True or False verify secure connection
         """
-        super().__init__(hassurl, token)
+        super().__init__(hassurl, token, verify)
         self._timeout = timeout
         self._assert_api_running()
 
@@ -51,6 +56,7 @@ class BaseClient(AuthenticatedClient):
                 headers=self._headers,
                 timeout=self._timeout,
                 params={**(params or {}), **kwargs} or None,
+                verify=self._verify,
             )
         )
 
@@ -64,6 +70,7 @@ class BaseClient(AuthenticatedClient):
                 headers=self._headers,
                 timeout=self._timeout,
                 json={**(json or {}), **kwargs} or None,
+                verify=self._verify,
             )
         )
 

--- a/src/hassapi/client/base.py
+++ b/src/hassapi/client/base.py
@@ -17,7 +17,7 @@ class BaseClient(AuthenticatedClient):
     """Class for basic API client functionality."""
 
     def __init__(
-        self, hassurl: Optional[str] = None, token: Optional[str] = None, verify: Optional[bool] = None, timeout: float = 3
+        self, hassurl: Optional[str] = None, token: Optional[str] = None, verify: bool = True, timeout: float = 3
     ):
         """Create Base Client object.
 

--- a/src/hassapi/client/base.py
+++ b/src/hassapi/client/base.py
@@ -9,10 +9,6 @@ from hassapi.exceptions import ClientError, get_error
 
 from .auth import AuthenticatedClient
 
-
-"""With the below, when using verify=False, InsecureRequestWarning output will be removed"""
-requests.packages.urllib3.disable_warnings()
-
 JsonResponseType = Union[Dict, List, str]
 HassValueType = Union[int, float, str, bool]
 

--- a/src/hassapi/client/base.py
+++ b/src/hassapi/client/base.py
@@ -10,8 +10,8 @@ from hassapi.exceptions import ClientError, get_error
 from .auth import AuthenticatedClient
 
 
-"""Uncomment the below if you don't want InsecureRequestWarning output when using verify=False"""
-# requests.packages.urllib3.disable_warnings()
+"""With the below, when using verify=False, InsecureRequestWarning output will be removed"""
+requests.packages.urllib3.disable_warnings()
 
 JsonResponseType = Union[Dict, List, str]
 HassValueType = Union[int, float, str, bool]

--- a/src/hassapi/client/states.py
+++ b/src/hassapi/client/states.py
@@ -12,8 +12,10 @@ class StatesClient(BaseClient):
         """Get ``entity_id`` state."""
         return State(**self._get(f"states/{entity_id}"))  # type: ignore
 
-    def set_state(self, entity_id: str, state: HassValueType) -> State:
-        """Set ``entity_id`` state."""
+    def set_state(self, entity_id: str, state: HassValueType, attributes: dict = None) -> State:
+        """Set ``entity_id`` state and optionally attributes."""
+        if attributes:
+            return State(**self._post(f"states/{entity_id}", state=state, attributes=attributes))  # type: ignore
         return State(**self._post(f"states/{entity_id}", state=state))  # type: ignore
 
     def get_states(self) -> StateList:


### PR DESCRIPTION
Good day,

thanks for the repo 
there might be the case, like mine where my Hass instance has a certificate and when making local requests wont be approved as is insecure.

The following PR adds an optional argument to the api where you could bypass verification. 
This would help my code to be updated with main branch

thank you