### PR TITLE
Websocket support, tests, maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install tox
+        run: pip install tox
+      - name: Run tests
+        run: tox -e pytest
+        env:
+          HASS_URL: X
+          HASS_TOKEN: X
+
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install tox
+        run: pip install tox
+      - name: Run flake8
+        run: tox -e flake8
+      - name: Run format check
+        run: tox -e format-check
+
+  type-check:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install tox
+        run: pip install tox
+      - name: Run mypy
+        run: tox -e mypy
+        env:
+          HASS_URL: X
+          HASS_TOKEN: X

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/README.md
+++ b/README.md
@@ -1,19 +1,179 @@
-## [Home Assistant](https://www.home-assistant.io/) Web API Client for Python
-[![PyPI - Downloads](https://img.shields.io/pypi/dm/hassapi?style=flat-square)](https://pypistats.org/packages/hassapi)
+# hassapi — Home Assistant Python API Client
 
-## Examples
+[![CI](https://github.com/hass-api/hassapi/actions/workflows/ci.yml/badge.svg)](https://github.com/hass-api/hassapi/actions/workflows/ci.yml)
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/hassapi?style=flat-square)](https://pypistats.org/packages/hassapi)
+[![PyPI - Version](https://img.shields.io/pypi/v/hassapi?style=flat-square)](https://pypi.org/project/hassapi/)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/hassapi?style=flat-square)](https://pypi.org/project/hassapi/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](LICENSE)
+
+A Python client for the [Home Assistant REST API](https://developers.home-assistant.io/docs/api/rest).
+
+---
+
+## Installation
+
+```bash
+pip install hassapi
+```
+
+## Quick Start
+
 ```python
 from hassapi import Hass
 
-hass = Hass(hassurl="http://IP_ADDRESS:8123/", token="YOUR_HASS_TOKEN")
+hass = Hass(hassurl="http://192.168.1.10:8123", token="YOUR_LONG_LIVED_TOKEN")
 
-hass.turn_on("light.bedroom_light")
+# Control devices
+hass.turn_on("light.living_room")
+hass.turn_off("switch.coffee_machine")
+hass.toggle("light.bedroom")
+
+# Read state
+state = hass.get_state("sensor.temperature")
+print(state.state)           # e.g. "21.5"
+print(state.attributes)      # dict of entity attributes
+print(state.last_changed)    # datetime
+
+# Run a script
 hass.run_script("good_morning")
+```
 
-# If you want to bypass certificate verification. Default set to True
-hass = Hass(hassurl="http://IP_ADDRESS:8123/", token="YOUR_HASS_TOKEN", verify=False)
+## Configuration
+
+### Constructor arguments
+
+```python
+hass = Hass(
+    hassurl="http://IP_ADDRESS:8123",
+    token="YOUR_HASS_TOKEN",
+    verify=True,   # Set to False to skip TLS certificate verification (e.g. self-signed certs)
+    timeout=3,     # Request timeout in seconds
+)
 ```
-## Installation
+
+### Environment variables
+
+If `hassurl` or `token` are not passed, the client reads from environment variables:
+
+```bash
+export HASS_URL=http://192.168.1.10:8123
+export HASS_TOKEN=your_long_lived_token
 ```
-pip install hassapi
+
+```python
+hass = Hass()  # reads from env
 ```
+
+---
+
+## API Reference
+
+### States
+
+```python
+# Get the state of a single entity
+state: State = hass.get_state("light.living_room")
+
+# Get states of all entities
+states: StateList = hass.get_states()
+
+# Set state and optionally attributes of an entity
+state: State = hass.set_state("sensor.my_sensor", state="42", attributes={"unit": "°C"})
+```
+
+**`State` object fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `entity_id` | `str` | Entity identifier |
+| `state` | `str` | Current state value |
+| `attributes` | `dict` | Entity attributes |
+| `last_changed` | `datetime` | When state last changed |
+| `last_updated` | `datetime` | When state was last updated |
+| `context` | `Context` | Context (id, parent_id, user_id) |
+
+---
+
+### Services
+
+```python
+# Call any service
+hass.call_service("turn_on", entity_id="light.living_room", brightness=200)
+
+# Convenience methods
+hass.turn_on("light.living_room")
+hass.turn_off("switch.fan")
+hass.toggle("light.bedroom")
+
+# Covers
+hass.open_cover("cover.garage")
+hass.close_cover("cover.garage")
+hass.set_cover_position("cover.garage", position=50)
+
+# Input entities
+hass.select_option("input_select.mode", option="Away")
+hass.set_value("input_number.brightness", value=75)
+
+# Scripts and shell commands
+hass.run_script("good_morning")
+hass.run_shell_command("backup")
+
+# List all available services
+services: ServiceList = hass.get_services()
+```
+
+---
+
+### Events
+
+```python
+# List all registered event listeners
+events: EventList = hass.get_events()
+
+# Fire an event
+hass.fire_event("MY_CUSTOM_EVENT")
+hass.fire_event("MY_CUSTOM_EVENT", event_data={"key": "value"})
+```
+
+---
+
+### Templates
+
+```python
+# Render a Jinja2 template
+result: str = hass.render_template("{{ states('sensor.temperature') }}")
+```
+
+---
+
+## Getting a Long-Lived Access Token
+
+1. Open Home Assistant in your browser
+2. Go to your profile: **Settings → Your profile → Security**
+3. Scroll to **Long-lived access tokens** and create one
+
+---
+
+## Contributing
+
+```bash
+# Install dev dependencies and run all checks
+pip install tox
+tox
+```
+
+Individual environments:
+
+```bash
+tox -e pytest        # run tests
+tox -e flake8        # lint
+tox -e mypy          # type check
+tox -e format        # auto-format code
+tox -e format-check  # check formatting without modifying
+```
+
+---
+
+## License
+
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/hassapi?style=flat-square)](https://pypi.org/project/hassapi/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](LICENSE)
 
-A Python client for the [Home Assistant REST API](https://developers.home-assistant.io/docs/api/rest).
+A Python client for the [Home Assistant REST API](https://developers.home-assistant.io/docs/api/rest) and [WebSocket API](https://developers.home-assistant.io/docs/api/websocket).
 
 ---
 
@@ -134,6 +134,42 @@ events: EventList = hass.get_events()
 hass.fire_event("MY_CUSTOM_EVENT")
 hass.fire_event("MY_CUSTOM_EVENT", event_data={"key": "value"})
 ```
+
+---
+
+### Real-time events (WebSocket)
+
+Subscriptions are non-blocking — they start a background thread and return immediately.
+
+```python
+import time
+
+def on_change(event):
+    data = event["data"]
+    print(data["entity_id"], data["old_state"]["state"], "->", data["new_state"]["state"])
+
+# Watch a specific entity for state changes
+hass.subscribe_to_state_changes(on_change, entity_id="light.living_room")
+
+# Watch all state changes
+hass.subscribe_to_state_changes(on_change)
+
+# Watch a specific event type
+hass.subscribe_to_events(on_change, event_type="call_service")
+
+# Watch all events
+hass.subscribe_to_events(on_change)
+
+# Keep the main thread alive while listening
+try:
+    while True:
+        time.sleep(1)
+except KeyboardInterrupt:
+    hass.unsubscribe()
+```
+
+The client reconnects automatically on dropped connections using exponential backoff,
+and gives up after 5 consecutive failures.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 line-length = 99
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 warn_redundant_casts = true
 warn_unused_ignores = true
 disallow_subclassing_any = false

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ packages = find:
 python_requires = >=3.9
 install_requires =
     requests
+    websocket-client
 
 [options.packages.find]
 where=src

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,9 +38,9 @@ test = pytest
 
 [coverage:run]
 branch = true
-parallel = true
+source = src/hassapi
 
 [coverage:report]
-skip_covered = true
 show_missing = true
-sort = Cover
+exclude_lines =
+    pragma: no cover

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,19 +13,19 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Topic :: Home Automation
 
 [options]
 package_dir=
     =src
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.9
 install_requires =
     requests
 

--- a/setup.py
+++ b/setup.py
@@ -24,14 +24,10 @@ def _get_release_version() -> str:
 def _write_version(version: str) -> None:
     """Write version to version.py."""
     with open("src/hassapi/version.py", "w") as file:
-        file.write(
-            textwrap.dedent(
-                f'''
+        file.write(textwrap.dedent(f'''
                 """Host package version, generated on build."""
                 __version__ = "{version}"
-                '''
-            ).lstrip()
-        )
+                ''').lstrip())
 
 
 version = _get_release_version()

--- a/src/hassapi/client/__init__.py
+++ b/src/hassapi/client/__init__.py
@@ -4,7 +4,8 @@ from .events import EventsClient
 from .services import ServicesClient
 from .states import StatesClient
 from .template import TemplateClient
+from .websocket import WebSocketClient
 
 
-class Hass(StatesClient, ServicesClient, TemplateClient, EventsClient):
+class Hass(StatesClient, ServicesClient, TemplateClient, EventsClient, WebSocketClient):
     """Home Assistant API Client."""

--- a/src/hassapi/client/auth.py
+++ b/src/hassapi/client/auth.py
@@ -11,8 +11,9 @@ class AuthenticatedClient:
         self, hassurl: Optional[str] = None, token: Optional[str] = None, verify: bool = True
     ):
         """Create Authenticated client."""
+        self._token = token or os.environ["HASS_TOKEN"]
         self._url = self._resolve_api_url(hassurl or os.environ["HASS_URL"])
-        self._headers = self._get_headers(token or os.environ["HASS_TOKEN"])
+        self._headers = self._get_headers(self._token)
         self._verify = verify
 
     def _resolve_api_url(self, hassurl: str) -> str:

--- a/src/hassapi/client/auth.py
+++ b/src/hassapi/client/auth.py
@@ -1,6 +1,5 @@
 """Class for HASS API authentication."""
 
-
 import os
 from typing import Dict, Optional
 

--- a/src/hassapi/client/base.py
+++ b/src/hassapi/client/base.py
@@ -92,4 +92,6 @@ class BaseClient(AuthenticatedClient):
     def _raise_error(self, status_code: int, url: str) -> None:
         """Raise custom error with description."""
         error = get_error(status_code)
-        raise error(f"{status_code} status code returned from {url}",)  # type: ignore
+        raise error(
+            f"{status_code} status code returned from {url}",
+        )  # type: ignore

--- a/src/hassapi/client/states.py
+++ b/src/hassapi/client/states.py
@@ -19,7 +19,11 @@ class StatesClient(BaseClient):
     ) -> State:
         """Set ``entity_id`` state and optionally attributes."""
         if attributes:
-            return State(**self._post(f"states/{entity_id}", state=state, attributes=attributes))  # type: ignore
+            return State(  # type: ignore
+                **self._post(
+                    f"states/{entity_id}", json={"state": state, "attributes": attributes}
+                )
+            )
         return State(**self._post(f"states/{entity_id}", state=state))  # type: ignore
 
     def get_states(self) -> StateList:

--- a/src/hassapi/client/websocket.py
+++ b/src/hassapi/client/websocket.py
@@ -1,0 +1,218 @@
+"""Client for real-time HA event subscriptions via WebSocket."""
+
+import json
+import logging
+import threading
+import time
+from typing import Callable, Dict, Optional
+
+import websocket
+
+from hassapi.exceptions import ClientError
+
+from .auth import AuthenticatedClient
+
+_LOGGER = logging.getLogger(__name__)
+
+CallbackType = Callable[[Dict], None]
+
+_MAX_RETRIES = 5
+_BASE_DELAY = 1.0
+_MAX_DELAY = 60.0
+_RESET_AFTER = 30.0  # reset retry counter if connection lived this long (seconds)
+
+
+class WebSocketClient(AuthenticatedClient):
+    """Client for real-time HA event subscriptions via WebSocket."""
+
+    def __init__(
+        self,
+        hassurl: Optional[str] = None,
+        token: Optional[str] = None,
+        verify: bool = True,
+        timeout: float = 3,
+    ):
+        """Create WebSocket client."""
+        super().__init__(hassurl, token, verify)
+        self._subscriptions: Dict[int, Dict] = {}
+        self._next_id: int = 1
+        self._ws: Optional[websocket.WebSocketApp] = None
+        self._thread: Optional[threading.Thread] = None
+        self._lock = threading.Lock()
+        self._stopping: bool = False
+        self._authenticated: bool = False
+        self._connected_at: Optional[float] = None
+
+    def subscribe_to_events(
+        self, callback: CallbackType, event_type: Optional[str] = None
+    ) -> None:
+        """Subscribe to HA events. Non-blocking — runs in a background thread.
+
+        Args:
+            callback: Function called with the event dict on each event.
+            event_type: Optional event type filter e.g. 'state_changed'. Subscribes
+                to all events if omitted.
+        """
+        msg: Dict = {"type": "subscribe_events"}
+        if event_type:
+            msg["event_type"] = event_type
+        self._add_subscription(msg=msg, callback=callback, entity_id=None)
+
+    def subscribe_to_state_changes(
+        self, callback: CallbackType, entity_id: Optional[str] = None
+    ) -> None:
+        """Subscribe to state_changed events. Non-blocking — runs in a background thread.
+
+        Args:
+            callback: Function called with the event dict on each state change.
+            entity_id: Optional entity to filter on e.g. 'light.living_room'. Subscribes
+                to all state changes if omitted.
+        """
+        msg: Dict = {"type": "subscribe_events", "event_type": "state_changed"}
+        self._add_subscription(msg=msg, callback=callback, entity_id=entity_id)
+
+    def unsubscribe(self) -> None:
+        """Unsubscribe all subscriptions and close the WebSocket connection."""
+        self._stopping = True
+        with self._lock:
+            if self._ws and self._authenticated:
+                for sub_id in self._subscriptions:
+                    try:
+                        self._ws.send(
+                            json.dumps(
+                                {
+                                    "id": self._next_id,
+                                    "type": "unsubscribe_events",
+                                    "subscription": sub_id,
+                                }
+                            )
+                        )
+                        self._next_id += 1
+                    except Exception:
+                        pass
+            if self._ws:
+                self._ws.close()
+        self._subscriptions.clear()
+        self._authenticated = False
+
+    def _add_subscription(
+        self, msg: Dict, callback: CallbackType, entity_id: Optional[str]
+    ) -> None:
+        """Register a subscription and send it if already authenticated."""
+        with self._lock:
+            sub_id = self._next_id
+            self._next_id += 1
+            msg["id"] = sub_id
+            self._subscriptions[sub_id] = {
+                "msg": msg,
+                "callback": callback,
+                "entity_id": entity_id,
+            }
+            if self._authenticated and self._ws:
+                self._ws.send(json.dumps(msg))
+        self._ensure_connected()
+
+    def _ensure_connected(self) -> None:
+        """Start the WebSocket background thread if not already running."""
+        if self._thread is None or not self._thread.is_alive():
+            self._stopping = False
+            self._ws = self._create_ws_app()
+            self._thread = threading.Thread(target=self._run_with_retry, daemon=True)
+            self._thread.start()
+
+    def _create_ws_app(self) -> websocket.WebSocketApp:
+        """Create a new WebSocketApp instance."""
+        return websocket.WebSocketApp(
+            self._get_ws_url(),
+            on_open=self._on_open,
+            on_message=self._on_message,
+            on_error=self._on_error,
+            on_close=self._on_close,
+        )
+
+    def _run_with_retry(self) -> None:
+        """Run WebSocket connection with exponential backoff retry on failure."""
+        attempt = 0
+        while not self._stopping:
+            self._connected_at = None
+            self._ws.run_forever()  # type: ignore[union-attr]
+
+            if self._stopping:
+                break
+
+            alive_for = (
+                time.monotonic() - self._connected_at if self._connected_at is not None else 0.0
+            )
+            if alive_for >= _RESET_AFTER:
+                attempt = 0
+
+            if attempt >= _MAX_RETRIES:
+                _LOGGER.error("WebSocket: giving up after %d retries.", _MAX_RETRIES)
+                break
+
+            delay = min(_BASE_DELAY * (2**attempt), _MAX_DELAY)
+            _LOGGER.warning(
+                "WebSocket disconnected. Retrying in %.1fs (attempt %d/%d).",
+                delay,
+                attempt + 1,
+                _MAX_RETRIES,
+            )
+            time.sleep(delay)
+            attempt += 1
+            self._authenticated = False
+            self._ws = self._create_ws_app()
+
+    def _on_open(self, ws: websocket.WebSocketApp) -> None:
+        """Handle WebSocket connection opened."""
+        self._connected_at = time.monotonic()
+        _LOGGER.debug("WebSocket connection opened.")
+
+    def _on_message(self, ws: websocket.WebSocketApp, message: str) -> None:
+        """Handle incoming WebSocket message."""
+        data = json.loads(message)
+        msg_type = data.get("type")
+
+        if msg_type == "auth_required":
+            ws.send(json.dumps({"type": "auth", "access_token": self._token}))
+        elif msg_type == "auth_ok":
+            _LOGGER.debug("WebSocket authenticated.")
+            with self._lock:
+                self._authenticated = True
+                for sub in self._subscriptions.values():
+                    ws.send(json.dumps(sub["msg"]))
+        elif msg_type == "auth_invalid":
+            _LOGGER.error("WebSocket authentication failed — check your token.")
+            self._stopping = True
+            ws.close()
+            raise ClientError("WebSocket authentication failed.")
+        elif msg_type == "event":
+            self._dispatch(data)
+
+    def _dispatch(self, data: Dict) -> None:
+        """Dispatch an incoming event to the matching callback."""
+        sub_id = data.get("id")
+        with self._lock:
+            sub = self._subscriptions.get(sub_id)  # type: ignore[arg-type]
+        if sub is None:
+            return
+        event = data["event"]
+        entity_id_filter = sub.get("entity_id")
+        if entity_id_filter and event.get("data", {}).get("entity_id") != entity_id_filter:
+            return
+        sub["callback"](event)
+
+    def _on_error(self, ws: websocket.WebSocketApp, error: Exception) -> None:
+        """Handle WebSocket error."""
+        _LOGGER.error("WebSocket error: %s", error)
+
+    def _on_close(
+        self, ws: websocket.WebSocketApp, close_status_code: int, close_msg: str
+    ) -> None:
+        """Handle WebSocket connection closed."""
+        _LOGGER.debug("WebSocket closed (code=%s): %s", close_status_code, close_msg)
+        self._authenticated = False
+
+    def _get_ws_url(self) -> str:
+        """Convert the HTTP API URL to a WebSocket URL."""
+        url = self._url.replace("https://", "wss://").replace("http://", "ws://")
+        return f"{url}/websocket"

--- a/src/hassapi/models/base.py
+++ b/src/hassapi/models/base.py
@@ -10,7 +10,8 @@ class Model:
     def __repr__(self) -> str:
         """Get object repr()."""
         name = type(self).__name__
-        return f"{name} with fields:\n" f"{_repr_dict(asdict(self))}"
+        fields = _repr_dict(asdict(self))  # type: ignore[call-overload]
+        return f"{name} with fields:\n{fields}"
 
 
 class ModelList(List):

--- a/tests/client/test_events.py
+++ b/tests/client/test_events.py
@@ -1,0 +1,34 @@
+from unittest.mock import patch
+
+from hassapi.client.events import EventsClient
+from hassapi.models import EventList
+
+MOCK_EVENT = {"event": "state_changed", "listener_count": 5}
+
+
+@patch("hassapi.client.base.BaseClient.__init__", return_value=None)
+def test_get_events(*args):
+    with patch.object(EventsClient, "_get", return_value=[MOCK_EVENT]) as mock_get:
+        result = EventsClient().get_events()
+    assert isinstance(result, EventList)
+    mock_get.assert_called_once_with("events")
+
+
+@patch("hassapi.client.base.BaseClient.__init__", return_value=None)
+def test_fire_event(*args):
+    with patch.object(
+        EventsClient, "_post", return_value={"message": "Event fired."}
+    ) as mock_post:
+        result = EventsClient().fire_event("MY_EVENT")
+    assert result == "Event fired."
+    mock_post.assert_called_once_with("events/MY_EVENT", json=None)
+
+
+@patch("hassapi.client.base.BaseClient.__init__", return_value=None)
+def test_fire_event_with_data(*args):
+    data = {"key": "value"}
+    with patch.object(
+        EventsClient, "_post", return_value={"message": "Event fired."}
+    ) as mock_post:
+        EventsClient().fire_event("MY_EVENT", event_data=data)
+    mock_post.assert_called_once_with("events/MY_EVENT", json=data)

--- a/tests/client/test_services.py
+++ b/tests/client/test_services.py
@@ -1,0 +1,98 @@
+from unittest.mock import patch
+
+import pytest
+
+from hassapi.client.services import ServicesClient
+from hassapi.models import ServiceList, StateList
+
+MOCK_STATE = {
+    "entity_id": "light.living_room",
+    "state": "on",
+    "attributes": {},
+    "context": {"id": "abc", "parent_id": None, "user_id": None},
+    "last_changed": "2024-01-01T00:00:00.000000+00:00",
+    "last_updated": None,
+    "last_reported": None,
+}
+
+MOCK_SERVICE = {"domain": "light", "services": {"turn_on": {}, "turn_off": {}}}
+
+
+@patch("hassapi.client.base.BaseClient.__init__", return_value=None)
+def test_get_services(*args):
+    with patch.object(ServicesClient, "_get", return_value=[MOCK_SERVICE]) as mock_get:
+        result = ServicesClient().get_services()
+    assert isinstance(result, ServiceList)
+    mock_get.assert_called_once_with("services")
+
+
+@patch("hassapi.client.base.BaseClient.__init__", return_value=None)
+def test_call_service(*args):
+    with patch.object(ServicesClient, "_post", return_value=[MOCK_STATE]) as mock_post:
+        result = ServicesClient().call_service("turn_on", entity_id="light.living_room")
+    assert isinstance(result, StateList)
+    mock_post.assert_called_once_with(
+        endpoint="/services/light/turn_on", entity_id="light.living_room"
+    )
+
+
+@patch("hassapi.client.base.BaseClient.__init__", return_value=None)
+def test_call_service_passes_kwargs(*args):
+    with patch.object(ServicesClient, "_post", return_value=[MOCK_STATE]) as mock_post:
+        ServicesClient().call_service("turn_on", entity_id="light.living_room", brightness=200)
+    mock_post.assert_called_once_with(
+        endpoint="/services/light/turn_on", entity_id="light.living_room", brightness=200
+    )
+
+
+@pytest.mark.parametrize("method", ["turn_on", "turn_off", "toggle"])
+@patch("hassapi.client.base.BaseClient.__init__", return_value=None)
+def test_toggle_methods(mock_init, method):
+    with patch.object(ServicesClient, "call_service", return_value=StateList()) as mock_call:
+        getattr(ServicesClient(), method)("light.living_room")
+    mock_call.assert_called_once_with(method, entity_id="light.living_room")
+
+
+@patch("hassapi.client.base.BaseClient.__init__", return_value=None)
+def test_select_option(*args):
+    with patch.object(ServicesClient, "call_service", return_value=StateList()) as mock_call:
+        ServicesClient().select_option("input_select.mode", option="Away")
+    mock_call.assert_called_once_with(
+        "select_option", entity_id="input_select.mode", option="Away"
+    )
+
+
+@patch("hassapi.client.base.BaseClient.__init__", return_value=None)
+def test_set_value(*args):
+    with patch.object(ServicesClient, "call_service", return_value=StateList()) as mock_call:
+        ServicesClient().set_value("input_number.brightness", value=75)
+    mock_call.assert_called_once_with("set_value", entity_id="input_number.brightness", value=75)
+
+
+@pytest.mark.parametrize("method", ["open_cover", "close_cover"])
+@patch("hassapi.client.base.BaseClient.__init__", return_value=None)
+def test_cover_methods(mock_init, method):
+    with patch.object(ServicesClient, "call_service", return_value=StateList()) as mock_call:
+        getattr(ServicesClient(), method)("cover.garage")
+    mock_call.assert_called_once_with(method, entity_id="cover.garage")
+
+
+@patch("hassapi.client.base.BaseClient.__init__", return_value=None)
+def test_set_cover_position(*args):
+    with patch.object(ServicesClient, "call_service", return_value=StateList()) as mock_call:
+        ServicesClient().set_cover_position("cover.garage", position=50)
+    mock_call.assert_called_once_with("set_cover_position", entity_id="cover.garage", position=50)
+
+
+@patch("hassapi.client.base.BaseClient.__init__", return_value=None)
+def test_run_script(*args):
+    with patch.object(ServicesClient, "_post", return_value=[]) as mock_post:
+        ServicesClient().run_script("good_morning")
+    mock_post.assert_called_once_with("/services/script/good_morning")
+
+
+@patch("hassapi.client.base.BaseClient.__init__", return_value=None)
+def test_run_shell_command(*args):
+    with patch.object(ServicesClient, "_post", return_value=[]) as mock_post:
+        ServicesClient().run_shell_command("backup")
+    mock_post.assert_called_once_with("/services/shell_command/backup")

--- a/tests/client/test_states.py
+++ b/tests/client/test_states.py
@@ -1,0 +1,52 @@
+from unittest.mock import patch
+
+from hassapi.client.states import StatesClient
+from hassapi.models import State, StateList
+
+MOCK_STATE = {
+    "entity_id": "light.living_room",
+    "state": "on",
+    "attributes": {"brightness": 200},
+    "context": {"id": "abc", "parent_id": None, "user_id": None},
+    "last_changed": "2024-01-01T00:00:00.000000+00:00",
+    "last_updated": "2024-01-01T00:00:00.000000+00:00",
+    "last_reported": None,
+}
+
+
+@patch("hassapi.client.base.BaseClient.__init__", return_value=None)
+def test_get_state(*args):
+    with patch.object(StatesClient, "_get", return_value=MOCK_STATE) as mock_get:
+        result = StatesClient().get_state("light.living_room")
+    assert isinstance(result, State)
+    assert result.entity_id == "light.living_room"
+    assert result.state == "on"
+    mock_get.assert_called_once_with("states/light.living_room")
+
+
+@patch("hassapi.client.base.BaseClient.__init__", return_value=None)
+def test_get_states(*args):
+    with patch.object(StatesClient, "_get", return_value=[MOCK_STATE]) as mock_get:
+        result = StatesClient().get_states()
+    assert isinstance(result, StateList)
+    assert len(result) == 1
+    mock_get.assert_called_once_with("states")
+
+
+@patch("hassapi.client.base.BaseClient.__init__", return_value=None)
+def test_set_state(*args):
+    with patch.object(StatesClient, "_post", return_value=MOCK_STATE) as mock_post:
+        result = StatesClient().set_state("light.living_room", "on")
+    assert isinstance(result, State)
+    mock_post.assert_called_once_with("states/light.living_room", state="on")
+
+
+@patch("hassapi.client.base.BaseClient.__init__", return_value=None)
+def test_set_state_with_attributes(*args):
+    attrs = {"brightness": 200}
+    with patch.object(StatesClient, "_post", return_value=MOCK_STATE) as mock_post:
+        result = StatesClient().set_state("light.living_room", "on", attributes=attrs)
+    assert isinstance(result, State)
+    mock_post.assert_called_once_with(
+        "states/light.living_room", json={"state": "on", "attributes": attrs}
+    )

--- a/tests/client/test_template.py
+++ b/tests/client/test_template.py
@@ -1,0 +1,11 @@
+from unittest.mock import patch
+
+from hassapi.client.template import TemplateClient
+
+
+@patch("hassapi.client.base.BaseClient.__init__", return_value=None)
+def test_render_template(*args):
+    with patch.object(TemplateClient, "_post", return_value="21.5") as mock_post:
+        result = TemplateClient().render_template("{{ states('sensor.temp') }}")
+    assert result == "21.5"
+    mock_post.assert_called_once_with("template", template="{{ states('sensor.temp') }}")

--- a/tests/client/test_websocket.py
+++ b/tests/client/test_websocket.py
@@ -1,0 +1,334 @@
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+import websocket
+
+from hassapi.client.websocket import _MAX_RETRIES, _RESET_AFTER, WebSocketClient
+from hassapi.exceptions import ClientError
+
+
+def make_client():
+    """Create a WebSocketClient with auth bypassed."""
+    with patch("hassapi.client.auth.AuthenticatedClient.__init__", return_value=None):
+        client = WebSocketClient()
+    client._token = "test_token"
+    client._url = "http://192.168.1.1:8123/api"
+    return client
+
+
+# --- URL conversion ---
+
+
+def test_get_ws_url_http():
+    assert make_client()._get_ws_url() == "ws://192.168.1.1:8123/api/websocket"
+
+
+def test_get_ws_url_https():
+    client = make_client()
+    client._url = "https://192.168.1.1:8123/api"
+    assert client._get_ws_url() == "wss://192.168.1.1:8123/api/websocket"
+
+
+# --- create_ws_app ---
+
+
+def test_create_ws_app_returns_websocket_app():
+    client = make_client()
+    app = client._create_ws_app()
+    assert isinstance(app, websocket.WebSocketApp)
+
+
+# --- subscribe_to_events ---
+
+
+def test_subscribe_to_events_registers_subscription():
+    client = make_client()
+    callback = MagicMock()
+    with patch.object(client, "_ensure_connected"):
+        client.subscribe_to_events(callback)
+    sub = list(client._subscriptions.values())[0]
+    assert sub["callback"] is callback
+    assert sub["entity_id"] is None
+    assert sub["msg"]["type"] == "subscribe_events"
+    assert "event_type" not in sub["msg"]
+
+
+def test_subscribe_to_events_with_event_type():
+    client = make_client()
+    with patch.object(client, "_ensure_connected"):
+        client.subscribe_to_events(MagicMock(), event_type="call_service")
+    sub = list(client._subscriptions.values())[0]
+    assert sub["msg"]["event_type"] == "call_service"
+
+
+def test_subscribe_to_events_assigns_incrementing_ids():
+    client = make_client()
+    with patch.object(client, "_ensure_connected"):
+        client.subscribe_to_events(MagicMock())
+        client.subscribe_to_events(MagicMock())
+    ids = list(client._subscriptions.keys())
+    assert ids == [1, 2]
+
+
+# --- subscribe_to_state_changes ---
+
+
+def test_subscribe_to_state_changes_registers_subscription():
+    client = make_client()
+    with patch.object(client, "_ensure_connected"):
+        client.subscribe_to_state_changes(MagicMock())
+    sub = list(client._subscriptions.values())[0]
+    assert sub["msg"]["event_type"] == "state_changed"
+    assert sub["entity_id"] is None
+
+
+def test_subscribe_to_state_changes_with_entity_id():
+    client = make_client()
+    with patch.object(client, "_ensure_connected"):
+        client.subscribe_to_state_changes(MagicMock(), entity_id="light.living_room")
+    sub = list(client._subscriptions.values())[0]
+    assert sub["entity_id"] == "light.living_room"
+
+
+def test_add_subscription_sends_immediately_when_authenticated():
+    client = make_client()
+    client._authenticated = True
+    client._ws = MagicMock()
+    with patch.object(client, "_ensure_connected"):
+        client.subscribe_to_events(MagicMock())
+    client._ws.send.assert_called_once()
+    sent = json.loads(client._ws.send.call_args[0][0])
+    assert sent["type"] == "subscribe_events"
+
+
+# --- ensure_connected ---
+
+
+def test_ensure_connected_starts_thread_when_none():
+    client = make_client()
+    with patch.object(client, "_create_ws_app", return_value=MagicMock()), patch(
+        "hassapi.client.websocket.threading.Thread"
+    ) as MockThread:
+        mock_thread = MagicMock()
+        MockThread.return_value = mock_thread
+        client._ensure_connected()
+    mock_thread.start.assert_called_once()
+
+
+def test_ensure_connected_does_not_restart_alive_thread():
+    client = make_client()
+    mock_thread = MagicMock()
+    mock_thread.is_alive.return_value = True
+    client._thread = mock_thread
+    with patch("hassapi.client.websocket.threading.Thread") as MockThread:
+        client._ensure_connected()
+    MockThread.assert_not_called()
+
+
+# --- unsubscribe ---
+
+
+def test_unsubscribe_sends_unsubscribe_messages():
+    client = make_client()
+    client._ws = MagicMock()
+    client._authenticated = True
+    client._subscriptions = {1: {"msg": {"id": 1, "type": "subscribe_events"}}}
+    client.unsubscribe()
+    client._ws.send.assert_called_once()
+    sent = json.loads(client._ws.send.call_args[0][0])
+    assert sent["type"] == "unsubscribe_events"
+    assert sent["subscription"] == 1
+
+
+def test_unsubscribe_closes_ws():
+    client = make_client()
+    client._ws = MagicMock()
+    client._authenticated = True
+    client._subscriptions = {1: {"msg": {}}}
+    client.unsubscribe()
+    client._ws.close.assert_called_once()
+
+
+def test_unsubscribe_clears_subscriptions():
+    client = make_client()
+    client._ws = MagicMock()
+    client._subscriptions = {1: {}, 2: {}}
+    client.unsubscribe()
+    assert len(client._subscriptions) == 0
+
+
+def test_unsubscribe_skips_send_when_not_authenticated():
+    client = make_client()
+    client._ws = MagicMock()
+    client._authenticated = False
+    client._subscriptions = {1: {"msg": {}}}
+    client.unsubscribe()
+    client._ws.send.assert_not_called()
+    client._ws.close.assert_called_once()
+
+
+# --- _on_open ---
+
+
+def test_on_open_sets_connected_at():
+    client = make_client()
+    assert client._connected_at is None
+    client._on_open(MagicMock())
+    assert client._connected_at is not None
+
+
+# --- _on_message ---
+
+
+def test_on_message_auth_required_sends_auth():
+    client = make_client()
+    mock_ws = MagicMock()
+    client._on_message(mock_ws, json.dumps({"type": "auth_required"}))
+    mock_ws.send.assert_called_once()
+    sent = json.loads(mock_ws.send.call_args[0][0])
+    assert sent["type"] == "auth"
+    assert sent["access_token"] == "test_token"
+
+
+def test_on_message_auth_ok_sets_authenticated_and_sends_subscriptions():
+    client = make_client()
+    mock_ws = MagicMock()
+    msg = {"id": 1, "type": "subscribe_events"}
+    client._subscriptions = {1: {"msg": msg, "callback": MagicMock(), "entity_id": None}}
+    client._on_message(mock_ws, json.dumps({"type": "auth_ok"}))
+    assert client._authenticated is True
+    mock_ws.send.assert_called_once_with(json.dumps(msg))
+
+
+def test_on_message_auth_invalid_raises_and_stops():
+    client = make_client()
+    mock_ws = MagicMock()
+    with pytest.raises(ClientError):
+        client._on_message(mock_ws, json.dumps({"type": "auth_invalid"}))
+    assert client._stopping is True
+    mock_ws.close.assert_called_once()
+
+
+def test_on_message_event_calls_dispatch():
+    client = make_client()
+    event = {"event_type": "state_changed", "data": {}}
+    msg = json.dumps({"type": "event", "id": 1, "event": event})
+    with patch.object(client, "_dispatch") as mock_dispatch:
+        client._on_message(MagicMock(), msg)
+    mock_dispatch.assert_called_once()
+
+
+# --- _dispatch ---
+
+
+def test_dispatch_calls_callback():
+    client = make_client()
+    callback = MagicMock()
+    event = {"event_type": "state_changed", "data": {}}
+    client._subscriptions = {1: {"callback": callback, "entity_id": None}}
+    client._dispatch({"id": 1, "event": event})
+    callback.assert_called_once_with(event)
+
+
+def test_dispatch_entity_id_filter_match():
+    client = make_client()
+    callback = MagicMock()
+    event = {"data": {"entity_id": "light.living_room"}}
+    client._subscriptions = {1: {"callback": callback, "entity_id": "light.living_room"}}
+    client._dispatch({"id": 1, "event": event})
+    callback.assert_called_once()
+
+
+def test_dispatch_entity_id_filter_no_match():
+    client = make_client()
+    callback = MagicMock()
+    event = {"data": {"entity_id": "light.bedroom"}}
+    client._subscriptions = {1: {"callback": callback, "entity_id": "light.living_room"}}
+    client._dispatch({"id": 1, "event": event})
+    callback.assert_not_called()
+
+
+def test_dispatch_unknown_subscription_id_is_ignored():
+    client = make_client()
+    client._subscriptions = {}
+    client._dispatch({"id": 99, "event": {}})  # should not raise
+
+
+# --- _on_error / _on_close ---
+
+
+def test_on_error_does_not_raise():
+    client = make_client()
+    client._on_error(MagicMock(), Exception("Connection refused"))
+
+
+def test_on_close_resets_authenticated():
+    client = make_client()
+    client._authenticated = True
+    client._on_close(MagicMock(), 1000, "Normal closure")
+    assert client._authenticated is False
+
+
+# --- _run_with_retry ---
+
+
+def test_run_with_retry_does_not_run_when_already_stopping():
+    client = make_client()
+    mock_ws = MagicMock()
+    client._ws = mock_ws
+    client._stopping = True
+    client._run_with_retry()
+    mock_ws.run_forever.assert_not_called()
+
+
+def test_run_with_retry_retries_on_disconnect():
+    client = make_client()
+    mock_ws = MagicMock()
+    calls = [0]
+
+    def run_forever():
+        calls[0] += 1
+        if calls[0] >= 3:
+            client._stopping = True
+
+    mock_ws.run_forever.side_effect = run_forever
+    client._ws = mock_ws
+    with patch.object(client, "_create_ws_app", return_value=mock_ws), patch(
+        "hassapi.client.websocket.time.sleep"
+    ):
+        client._run_with_retry()
+    assert mock_ws.run_forever.call_count == 3
+
+
+def test_run_with_retry_gives_up_after_max_retries():
+    client = make_client()
+    mock_ws = MagicMock()
+    client._ws = mock_ws
+    with patch.object(client, "_create_ws_app", return_value=mock_ws), patch(
+        "hassapi.client.websocket.time.sleep"
+    ):
+        client._run_with_retry()
+    assert mock_ws.run_forever.call_count == _MAX_RETRIES + 1
+
+
+def test_run_with_retry_resets_counter_on_long_connection():
+    client = make_client()
+    mock_ws = MagicMock()
+    calls = [0]
+
+    def run_forever():
+        calls[0] += 1
+        # Simulate a long-lived connection on the 4th call
+        if calls[0] == 4:
+            client._connected_at = time.monotonic() - _RESET_AFTER - 1
+
+    mock_ws.run_forever.side_effect = run_forever
+    client._ws = mock_ws
+    with patch.object(client, "_create_ws_app", return_value=mock_ws), patch(
+        "hassapi.client.websocket.time.sleep"
+    ):
+        client._run_with_retry()
+    # Without reset: _MAX_RETRIES + 1 = 6. With reset at call 4: 9.
+    assert mock_ws.run_forever.call_count > _MAX_RETRIES + 1

--- a/tox.ini
+++ b/tox.ini
@@ -10,15 +10,14 @@ envlist =
 [testenv]
 basepython = python3
 deps =
-    pytest: coverage
-    pytest: pytest
+    pytest: pytest-cov
     flake8: flake8 >= 7.0
     flake8: flake8-docstrings >= 1.7
     flake8: pep8-naming >= 0.13
     mypy: mypy >= 1.5
     mypy: types-requests
 commands =
-    pytest: pytest --verbose
+    pytest: pytest --verbose --cov=hassapi --cov-report=term-missing --cov-fail-under=80
     mypy: mypy --no-incremental src/hassapi
 setenv =
     HASS_URL=X
@@ -58,10 +57,3 @@ line_length = 99
 known_first_party = hassapi
 known_third_party = pytest,requests,setuptools
 
-[coverage:run]
-source =
-    src/hassapi
-
-[coverage:report]
-exclude_lines =
-    pragma: no cover

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ line_length = 99
 known_first_party = hassapi
 known_third_party = pytest,requests,setuptools
 
-[covrage:run]
+[coverage:run]
 source =
     src/hassapi
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,12 +12,11 @@ basepython = python3
 deps =
     pytest: coverage
     pytest: pytest
-    flake8: flake8 >= 3.8.0, <4
-    flake8: flake8-docstrings >= 1.5.0, <2
-    flake8: pep8-naming >= 0.10.0, <1
-    flake8: flake8-colors >= 0.1.6, <1
-    flake8: pydocstyle == 5.0.2
-    mypy: mypy == 0.812
+    flake8: flake8 >= 7.0
+    flake8: flake8-docstrings >= 1.7
+    flake8: pep8-naming >= 0.13
+    mypy: mypy >= 1.5
+    mypy: types-requests
 commands =
     pytest: pytest --verbose
     mypy: mypy --no-incremental src/hassapi
@@ -33,16 +32,13 @@ commands =
 [testenv:format]
 basepython = python3
 description = format source code
-deps = black == 19.10b0
-       click == 8.0.2
-       isort[pyproject] == 4.3.21
-       seed-isort-config >= 1.2.0
+deps = black >= 24.0
+       isort[pyproject] >= 5.0
 extras =
 skip_install = true
 commands =
-    - seed-isort-config --application-directories src,tests
     black src tests setup.py
-    isort -rc src tests setup.py
+    isort src tests setup.py
 
 [testenv:format-check]
 basepython = python3
@@ -51,12 +47,10 @@ deps = {[testenv:format]deps}
 skip_install = {[testenv:format]skip_install}
 extras = {[testenv:format]extras}
 commands =
-    seed-isort-config --application-directories src,tests
     black --diff --check src tests setup.py
-    isort --diff -rc --check-only src tests setup.py
+    isort --diff --check-only src tests setup.py
 
 [isort]
-not_skip = __init__.py
 multi_line_output = 3
 include_trailing_comma = True
 force_grid_wrap = 0


### PR DESCRIPTION
### Added
- WebSocket support: `subscribe_to_events()`, `subscribe_to_state_changes()`, `unsubscribe()` with automatic reconnection
- CI pipeline via GitHub Actions (Python 3.9–3.14)
- Test coverage up to 96.6% (enforced minimum 80%)

### Changed
- Minimum Python version is now 3.9
- Rewrote README with full API reference and examples

### Fixed
- Various linting and type checking issues
